### PR TITLE
Refactored the vowel-finding example in Scope (Chapter 7)

### DIFF
--- a/book-2-the-novice/chapters/JS_SCOPE.md
+++ b/book-2-the-novice/chapters/JS_SCOPE.md
@@ -75,7 +75,7 @@ function containsVowels (wordParameter)
         method on a string will return `null` if there
         are no matches, otherwise, an array will be returned.
     */
-    const doesItHaveOne = wordParameter.match(/aeiou/gi)
+    const doesItHaveOne = wordParameter.match(/[aeiou]/gi)
 
     return doesItHaveOne === null
 

--- a/book-2-the-novice/chapters/JS_SCOPE.md
+++ b/book-2-the-novice/chapters/JS_SCOPE.md
@@ -77,7 +77,7 @@ function containsVowels (wordParameter)
     */
     const doesItHaveOne = wordParameter.match(/[aeiou]/gi)
 
-    return doesItHaveOne === null
+    return doesItHaveOne !== null
 
 }  // End of `function` scope
 


### PR DESCRIPTION
Refactored a couple of syntax things in the `doesItHaveOne` vowel-finding example in the chapter on Scope. Two proposed changes:

1. The original regex was looking for the string `aeiou`. I added brackets to the regex so that it looks for any of those vowels, but not necessarily together.
1. The original return statement returned `true` if the `.match` method returned `null` (i.e. if the word didn't have any vowels.) I changed it to `!== null` so that it returns`true` if the word _does_ contain a vowel and `false` if the word _doesn't_ contain a vowel.
