### PR TITLE
change filename in instructions

### DIFF
--- a/book-2-the-novice/chapters/JS_DATA.md
+++ b/book-2-the-novice/chapters/JS_DATA.md
@@ -246,7 +246,7 @@ const loadDatabase = function (localStorageKey) {
 
 Now you can use those two functions to save, and load, your home inventory database from localStorage. The only one that you're going to use right now is the `saveDatabase` function.
 
-Here's what your `database.js` file should look like.
+Here's what your `storage.js` file should look like.
 
 ```js
 /*


### PR DESCRIPTION
The students' first JS file is called `storage.js` (where they put the data in to localStorage).
The retrieval js file is called `database.js`.

In the instructions, the `storage.js` file is mistakenly referred to as `database.js` which some students found confusing.

I have changed this single word to alleviate future confusion. 
😃 