### PR TITLE
Fixed two syntax bugs in first React chapters 1 & 2

### DIFF
--- a/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
+++ b/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
@@ -68,13 +68,15 @@ import React, { Component } from 'react'
 
 
 export default class EmployeeList extends Component {
-   return (
-      <section>
-        {this.props.employees.map(employee => {
-            return <div>{employee.name}</div>
-        })}
-      </section>
-    );
+    render(){
+    return (
+        <section>
+            {this.props.employees.map(employee => {
+                return <div>{employee.name}</div>
+            })}
+        </section>
+        );
+    }
 }
 ```
 

--- a/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
+++ b/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
@@ -69,12 +69,14 @@ import React, { Component } from 'react'
 
 export default class EmployeeList extends Component {
     render(){
-    return (
-        <section>
-            {this.props.employees.map(employee => {
-                return <div>{employee.name}</div>
-            })}
-        </section>
+        return (
+            <section>
+                {this.props.employees.map(employee => {
+                    return <div>
+                        {employee.name}
+                    </div>
+                })}
+            </section>
         );
     }
 }

--- a/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
+++ b/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
@@ -68,17 +68,13 @@ import React, { Component } from 'react'
 
 
 export default class EmployeeList extends Component {
-    render() {
-        return ({
-            <section>
-                this.props.employees.map(employee => (
-                    <div>
-                        {employee.name}
-                    </div>
-                ))
-            <section>
-        })
-    }
+   return (
+      <section>
+        {this.props.employees.map(employee => {
+            return <div>{employee.name}</div>
+        })}
+      </section>
+    );
 }
 ```
 

--- a/book-4-the-apprentice/chapters/REACT_BASICS.md
+++ b/book-4-the-apprentice/chapters/REACT_BASICS.md
@@ -77,7 +77,7 @@ class Kennel extends Component {
     }
 }
 
-ReactDOM.render(<Kennel />, document.querySelector("root"));
+ReactDOM.render(<Kennel />, document.querySelector("#root"));
 ```
 
 ### Child Component


### PR DESCRIPTION
I was working through the exercises in the first two chapters of Book 4 and ran into two minor syntax errors in the example code. I fixed them and pushed them up for review.

###  Fix from Chapter One:
The example code used `document.querySelector` to select the dom element with an id of `root`, but there wasn't a hash symbol nothing was selected.

### Fix from Chapter Two:
The example code was throwing errors for me. I moved the JSX curly brackets around the loop (rather than around the whole section) and added a `return` statement to the `.map()` method and that made the errors go away. (Full disclosure: I'm new to React and not at all confident that this is the best/ only way to fix this bug, so please let me know if there's a better way to fix!)




