### PR TITLE
Fixed employee vs. employees syntax in React Chapter 2

### DIFF
--- a/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
+++ b/book-4-the-apprentice/chapters/COMPONENT_STATE_PROPS.md
@@ -33,7 +33,7 @@ export default class Kennel extends Component {
         return (
             <React.Fragment>
                 <LocationList locations={this.state.locations} />
-                <EmployeeList employee={this.state.employees} />
+                <EmployeeList employees={this.state.employees} />
             </React.Fragment>
         );
     }


### PR DESCRIPTION
In Chapter Book 4, Chapter 2 (State and Props), we passed something called `employee` into a child component but referenced it as `this.props.employees`. I fixed it so it's plural in both places. 👍 