### PR TITLE
Tiny change in parameter order

### DIFF
--- a/book-2-the-novice/chapters/JS_DATA.md
+++ b/book-2-the-novice/chapters/JS_DATA.md
@@ -214,7 +214,7 @@ The first step, is to refactor the function to receive an argument specifying th
 In the code below, you will see how to use the `JSON.stringify` method which allows you to take an in-memory object, and convert it to a string representation of the object that can be saved in local storage. This is important, because only strings can be saved in local storage.
 
 ```js
-const saveDatabase = function (databaseObject, localStorageKey) {
+const saveDatabase = function (localStorageKey, databaseObject) {
     /*
         Convert the Object into a string.
     */


### PR DESCRIPTION
The order of parameters for `setData()` is confusing students. Since they use `localStorage.setItem()` and it takes a `key` and a `value` argument (in that order), but this function takes a `value` and a `key` argument, it threw them off. Small change, but I think it will help some of them keep things straight.  