### PR TITLE
Switch reference to commonjs with es6 modules

### DIFF
--- a/book-3-the-initiate/chapters/DAILY_JOURNAL_BROWSERIFY.md
+++ b/book-3-the-initiate/chapters/DAILY_JOURNAL_BROWSERIFY.md
@@ -43,7 +43,7 @@ Update your `src/lib/grunt/aliases.yaml` file to run the task.
 
 ## Instructions
 
-> **Task**: Take existing JavaScript modules, and refactor as Browerify syntax modules with `require` and `modules.exports`.
+> **Task**: Take existing JavaScript modules, and refactor as Browerify syntax modules with `import` and `export`.
 
 Your `index.html` should have several script components at the bottom. Below is an example only, your files names do not need to match this example.
 

--- a/book-3-the-initiate/chapters/JS_MAPS.md
+++ b/book-3-the-initiate/chapters/JS_MAPS.md
@@ -221,7 +221,7 @@ Again, these aren't major calculations, but we can optimize this process with a 
 > **File:** scripts/articles/controller.js
 
 ```js
-import { factory } from "./articles/factory";
+import { factory } from "./articles/factory"
 
 document.addEventListener("articles.loaded", () => {
     const finalHTML = factory.condensed

--- a/book-3-the-initiate/chapters/JS_MAPS.md
+++ b/book-3-the-initiate/chapters/JS_MAPS.md
@@ -221,7 +221,7 @@ Again, these aren't major calculations, but we can optimize this process with a 
 > **File:** scripts/articles/controller.js
 
 ```js
-const factory = require("articles/factory")
+import { factory } from "./articles/factory";
 
 document.addEventListener("articles.loaded", () => {
     const finalHTML = factory.condensed

--- a/book-3-the-initiate/chapters/JS_MAPS.md
+++ b/book-3-the-initiate/chapters/JS_MAPS.md
@@ -221,7 +221,7 @@ Again, these aren't major calculations, but we can optimize this process with a 
 > **File:** scripts/articles/controller.js
 
 ```js
-import { factory } from "./articles/factory"
+import factory from "./articles/factory"
 
 document.addEventListener("articles.loaded", () => {
     const finalHTML = factory.condensed


### PR DESCRIPTION
Remove possibly lingering references to CommonJS modules in favor of using ES6 modules. These are the only references to CommonJS outside a node environment (like the grunt chapter)