### PR TITLE
change h5 tag to div tag and wrap animal name in h5 tag

### DIFF
--- a/book-4-the-apprentice/chapters/FUNCTIONS_AS_PROPS.md
+++ b/book-4-the-apprentice/chapters/FUNCTIONS_AS_PROPS.md
@@ -64,13 +64,13 @@ export default class AnimalList extends Component {
                 this.props.animals.map(animal =>
                     <div key={animal.id} className="card">
                         <div className="card-body">
-                            <h5 className="card-title">
+                            <div className="card-title">
                                 <img src={dog} className="icon--dog" />
-                                {animal.name}
+                                <h5>{animal.name}</h5>
                                 <button
                                     onClick={() => this.props.deleteAnimal(animal.id)}
                                     className="card-link">Delete</button>
-                            </h5>
+                            </div>
                         </div>
                     </div>
                 )


### PR DESCRIPTION
Issue: Several students have come seeking help with errors due to nested header elements within the h5 tag.

Changed the h5 tag to a div, which allows for nesting of additional header elements within, such as the animal owner's name, etc. 