### PR TITLE
update food API exercise

### DIFF
--- a/book-2-the-neophyte/chapters/FETCH_INTRO.md
+++ b/book-2-the-neophyte/chapters/FETCH_INTRO.md
@@ -165,7 +165,11 @@ fetch("http://localhost:8088/food")
             fetch(`https://world.openfoodfacts.org/api/v0/product/${what goes here?}.json`)
                 .then(response => response.json())
                 .then(productInfo => {
-                    food.ingredients = productInfo.product.ingredients
+                    if (productInfo.product.ingredients_text) {
+                      food.ingredients = productInfo.product.ingredients_text
+                    } else {
+                      food.ingredients = "no ingredients listed"
+                    }
 
                     // Produce HTML representation
                     const foodAsHTML = foodFactory(food)


### PR DESCRIPTION
As written, the example code indicates that students should use `productInfo.product.ingredients` when adding ingredients to their food db items. That is usually an array of objects. I changed it to `productInfo.product.ingredients_text`, which is more user-friendly. Also added an if/else to check for `ingredients_text`, since a few products don't have one.