### PR TITLE
Removed unavailable video link from HTML Components chapter

### DIFF
--- a/book-1-the-novice/chapters/HTML_COMPONENTS.md
+++ b/book-1-the-novice/chapters/HTML_COMPONENTS.md
@@ -159,7 +159,6 @@ Styling components intelligently can be handled through naming your classes acco
 ## Videos to Watch
 
 1. [Introduction to BEM - A front-end methodology](https://www.youtube.com/watch?v=IO-4Z32O--c)
-1. [020 CSS Architecture Components and BEM](https://www.youtube.com/watch?v=8wX78mtlNyU)
 
 ## Practice
 


### PR DESCRIPTION
A student brought to our attention that the following link is a video that is no longer available [https://www.youtube.com/watch?v=8wX78mtlNyU](https://www.youtube.com/watch?v=8wX78mtlNyU). 
Verified that the CSS Architecture Components and BEM video was no longer available and removed link from the HTML Components Chapter.