### PR TITLE
Corrected way a function was written

### DIFF
--- a/book-2-the-neophyte/chapters/DAILY_JOURNAL_DATA_DOM.md
+++ b/book-2-the-neophyte/chapters/DAILY_JOURNAL_DATA_DOM.md
@@ -71,7 +71,7 @@ const journalEntries = [
 
     Arguments: journalEntry (object)
 */
-const makeJournalEntryComponent = (journalEntry) {
+const makeJournalEntryComponent = (journalEntry) => {
     // Create your own HTML structure for a journal entry
     return `
 


### PR DESCRIPTION
In `DAILY_JOURNAL_DATA_DOM.md`, on line 74, the `makeJournalEntryComponent` function was missing a fat arrow to make it an arrow function. Verify that the fat arrow now exists and the `makeJournalEntryComponent` is correctly written as a function