### PR TITLE
glassdale chapter 5 sample code

### DIFF
--- a/book-2-glassdale-pd/chapters/GLASSDALE_EVENT_HUB.md
+++ b/book-2-glassdale-pd/chapters/GLASSDALE_EVENT_HUB.md
@@ -88,7 +88,7 @@ eventHub.addEventListener("change", event => {
     if (event.target.id === "crimeSelect") {
         // Create custom event. Provide an appropriate name.
         const customEvent = new CustomEvent("crimeChosen", {
-            details: {
+            detail: {
                 crimeThatWasChosen: event.target.value
             }
         })


### PR DESCRIPTION
Confirm that in Glassdale chapter 5, in the sample code, the custom event references "detail" and not "details"