### PR TITLE
Add script tag instrux to JS chapter

### DIFF
--- a/book-1-martins-aquarium/chapters/EXPORTING_FISH.md
+++ b/book-1-martins-aquarium/chapters/EXPORTING_FISH.md
@@ -41,6 +41,13 @@ for (const fish of allTheFish) {
     console.log(fish)
 }
 ```
+Now, you're ready to see if your fish print to the console. But, first you'll need to tell your browser to load and run your javascript. To do that, add a `<script>` tag to `index.html`, right above the closing `<body>` tag.
+
+```js
+<script type="module" src="scripts/main.js"></script>
+``` 
+
+Designating `main.js` as `type="module"` allows you to utilize the import and export syntax. Note that `main.js` is the only file we need to load via a `<script>` tag. The import statements will cause a daisy-chain effect of sorts, causing any other imported modules to also be loaded and evaluated by the browser.
 
 ## Next Steps
 


### PR DESCRIPTION
Letting them figure it out has its limits 😄 
Since we ask students to watch us code then go try the chapters for themselves, having some of the basics in the chapters seems like it will lower the frustration level. So, I have added instrux for putting a script tag into index.html, with a short word about why `type="module"` is needed, in case they have played with script tags in an earlier life.
