### PR TITLE
Fixed Modern Farm broken link

### DIFF
--- a/projects/tier-1/modern-farm/chapters/MF_INSTALL_PLAN.md
+++ b/projects/tier-1/modern-farm/chapters/MF_INSTALL_PLAN.md
@@ -15,7 +15,7 @@ In this project, you will be practicing the following skills.
 Open a new terminal window, copy pasta the following command into the terminal and hit enter to run it. It will create a basic file structure for you and create some starter code in the `~/workspace/modern-farm` directory.
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nashville-software-school/client-side-mastery/cohort-48/project-modern-farm/chapters/scripts/modern-farm-install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nashville-software-school/client-side-mastery/cohort-48/projects/tier-1/modern-farm/chapters/scripts/modern-farm-install.sh)"
 ```
 
 Then run the following command in your terminal to change directory to the project directory.


### PR DESCRIPTION
## To Test
- navigate to `projects/tier-1/modern-farm/chapters/MF_INSTALL_PLAN.md` and verify that the link to the installer script works now

Just had to tweak the URL to reflect the new folder structure.