### PR TITLE
Flexible Workspace Location

### DIFF
--- a/book-1-martins-aquarium/chapters/CUSTOM_WORKSPACE.md
+++ b/book-1-martins-aquarium/chapters/CUSTOM_WORKSPACE.md
@@ -1,0 +1,10 @@
+# Setting Up Your Workspace
+
+By default, you will all use `~/workspace` as your working directory. However, some of you may want to put this folder in another location. Here is how you do that.
+
+Let's say you want to keep your workspace under `~/nss/workspace`.
+```
+mkdir -p ~/nss/workspace
+echo "export NSS_WORKSPACE=~/nss/workspace" >> ~/.bash_env
+echo "export BASH_ENV=~/.bash_env" >> ~/.bashrc
+```

--- a/book-2-leonids-toys/scripts/flower-assessment.sh
+++ b/book-2-leonids-toys/scripts/flower-assessment.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/flowers"
-cd "$WORKSPACE/flowers"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/flowers"
+cd "$NSS_WORKSPACE/flowers"
 
 
 echo 'const flowers = [

--- a/book-2-leonids-toys/scripts/flower-assessment.sh
+++ b/book-2-leonids-toys/scripts/flower-assessment.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/flowers
-cd $HOME/workspace/flowers
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/flowers"
+cd "$WORKSPACE/flowers"
 
 
 echo 'const flowers = [

--- a/book-2-leonids-toys/scripts/flower-assessment.sh
+++ b/book-2-leonids-toys/scripts/flower-assessment.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/flowers"
 cd "$NSS_WORKSPACE/flowers"
 

--- a/book-3-deshawns-dog-walking/chapters/scripts/assessment.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/assessment.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/assessments/debugging-events/scripts"
-mkdir -p "$WORKSPACE/assessments/debugging-events/styles"
-cd "$WORKSPACE/assessments/debugging-events"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/assessments/debugging-events/scripts"
+mkdir -p "$NSS_WORKSPACE/assessments/debugging-events/styles"
+cd "$NSS_WORKSPACE/assessments/debugging-events"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-3-deshawns-dog-walking/chapters/scripts/assessment.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/assessment.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/assessments/debugging-events/scripts
-mkdir -p $HOME/workspace/assessments/debugging-events/styles
-cd $HOME/workspace/assessments/debugging-events
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/assessments/debugging-events/scripts"
+mkdir -p "$WORKSPACE/assessments/debugging-events/styles"
+cd "$WORKSPACE/assessments/debugging-events"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-3-deshawns-dog-walking/chapters/scripts/assessment.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/assessment.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/assessments/debugging-events/scripts"
 mkdir -p "$NSS_WORKSPACE/assessments/debugging-events/styles"
 cd "$NSS_WORKSPACE/assessments/debugging-events"

--- a/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/brewed-awakenings/scripts"
-mkdir -p "$WORKSPACE/brewed-awakenings/styles"
-cd "$WORKSPACE/brewed-awakenings"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/brewed-awakenings/scripts"
+mkdir -p "$NSS_WORKSPACE/brewed-awakenings/styles"
+cd "$NSS_WORKSPACE/brewed-awakenings"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/brewed-awakenings/scripts"
 mkdir -p "$NSS_WORKSPACE/brewed-awakenings/styles"
 cd "$NSS_WORKSPACE/brewed-awakenings"

--- a/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/brewed-awakenings/scripts
-mkdir -p $HOME/workspace/brewed-awakenings/styles
-cd $HOME/workspace/brewed-awakenings
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/brewed-awakenings/scripts"
+mkdir -p "$WORKSPACE/brewed-awakenings/styles"
+cd "$WORKSPACE/brewed-awakenings"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/dog-walking/scripts
-mkdir -p $HOME/workspace/dog-walking/styles
-cd $HOME/workspace/dog-walking
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/dog-walking/scripts"
+mkdir -p "$WORKSPACE/dog-walking/styles"
+cd "$WORKSPACE/dog-walking"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/dog-walking/scripts"
-mkdir -p "$WORKSPACE/dog-walking/styles"
-cd "$WORKSPACE/dog-walking"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/dog-walking/scripts"
+mkdir -p "$NSS_WORKSPACE/dog-walking/styles"
+cd "$NSS_WORKSPACE/dog-walking"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/dog-walking/scripts"
 mkdir -p "$NSS_WORKSPACE/dog-walking/styles"
 cd "$NSS_WORKSPACE/dog-walking"

--- a/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
+++ b/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -u
 
-# set NSS_WORKSPACE in your environment to change the location of your workspace
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
 
 mkdir -p "$NSS_WORKSPACE/kneel-diamonds/scripts"
 mkdir -p "$NSS_WORKSPACE/kneel-diamonds/styles"

--- a/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
+++ b/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/kneel-diamonds/scripts
-mkdir -p $HOME/workspace/kneel-diamonds/styles
-cd $HOME/workspace/kneel-diamonds
+# set WORKSPACE in your environment to change the location of your workspace
+WORKSPACE="$HOME/workspace"
+
+mkdir -p "$WORKSPACE/kneel-diamonds/scripts"
+mkdir -p "$WORKSPACE/kneel-diamonds/styles"
+cd "$WORKSPACE/kneel-diamonds"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
+++ b/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -u
 
-# set WORKSPACE in your environment to change the location of your workspace
-WORKSPACE="$HOME/workspace"
+# set NSS_WORKSPACE in your environment to change the location of your workspace
+NSS_WORKSPACE="$HOME/workspace"
 
-mkdir -p "$WORKSPACE/kneel-diamonds/scripts"
-mkdir -p "$WORKSPACE/kneel-diamonds/styles"
-cd "$WORKSPACE/kneel-diamonds"
+mkdir -p "$NSS_WORKSPACE/kneel-diamonds/scripts"
+mkdir -p "$NSS_WORKSPACE/kneel-diamonds/styles"
+cd "$NSS_WORKSPACE/kneel-diamonds"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
+++ b/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/sink-repair/api"
-mkdir -p "$WORKSPACE/sink-repair/src/scripts"
-mkdir -p "$WORKSPACE/sink-repair/src/styles"
-cd "$WORKSPACE/sink-repair/api"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/sink-repair/api"
+mkdir -p "$NSS_WORKSPACE/sink-repair/src/scripts"
+mkdir -p "$NSS_WORKSPACE/sink-repair/src/styles"
+cd "$NSS_WORKSPACE/sink-repair/api"
 
 echo '{
     "plumbers": [],
@@ -21,7 +21,7 @@ echo '{
     ]
 }' > database.json
 
-cd "$WORKSPACE/sink-repair/src"
+cd "$NSS_WORKSPACE/sink-repair/src"
 
 echo '<!doctype html>
 <html lang="en">

--- a/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
+++ b/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/sink-repair/api"
 mkdir -p "$NSS_WORKSPACE/sink-repair/src/scripts"
 mkdir -p "$NSS_WORKSPACE/sink-repair/src/styles"

--- a/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
+++ b/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/sink-repair/api
-mkdir -p $HOME/workspace/sink-repair/src/scripts
-mkdir -p $HOME/workspace/sink-repair/src/styles
-cd $HOME/workspace/sink-repair/api
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/sink-repair/api"
+mkdir -p "$WORKSPACE/sink-repair/src/scripts"
+mkdir -p "$WORKSPACE/sink-repair/src/styles"
+cd "$WORKSPACE/sink-repair/api"
 
 echo '{
     "plumbers": [],
@@ -20,7 +21,7 @@ echo '{
     ]
 }' > database.json
 
-cd $HOME/workspace/sink-repair/src
+cd "$WORKSPACE/sink-repair/src"
 
 echo '<!doctype html>
 <html lang="en">

--- a/projects/tier-1/modern-farm/chapters/scripts/modern-farm-install.sh
+++ b/projects/tier-1/modern-farm/chapters/scripts/modern-farm-install.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/modern-farm/src/scripts/seeds"
 mkdir -p "$NSS_WORKSPACE/modern-farm/src/styles"
 mkdir -p "$NSS_WORKSPACE/modern-farm/test"

--- a/projects/tier-1/modern-farm/chapters/scripts/modern-farm-install.sh
+++ b/projects/tier-1/modern-farm/chapters/scripts/modern-farm-install.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/modern-farm/src/scripts/seeds"
-mkdir -p "$WORKSPACE/modern-farm/src/styles"
-mkdir -p "$WORKSPACE/modern-farm/test"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/modern-farm/src/scripts/seeds"
+mkdir -p "$NSS_WORKSPACE/modern-farm/src/styles"
+mkdir -p "$NSS_WORKSPACE/modern-farm/test"
 
-cd "$WORKSPACE/modern-farm"
+cd "$NSS_WORKSPACE/modern-farm"
 git init
 
 echo '{
@@ -54,7 +54,7 @@ echo '{
 }
 ' > package.json
 
-cd "$WORKSPACE/modern-farm/test"
+cd "$NSS_WORKSPACE/modern-farm/test"
 
 echo 'import { createPlan } from "../src/scripts/plan.js"
 import { plantSeeds } from "../src/scripts/tractor.js";
@@ -189,7 +189,7 @@ describe("Harvesting the grown plants", () => {
 })
 ' > farm.test.js
 
-cd "$WORKSPACE/modern-farm/src"
+cd "$NSS_WORKSPACE/modern-farm/src"
 
 echo '<!doctype html>
 <html lang="en">

--- a/projects/tier-1/modern-farm/chapters/scripts/modern-farm-install.sh
+++ b/projects/tier-1/modern-farm/chapters/scripts/modern-farm-install.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/modern-farm/src/scripts/seeds
-mkdir -p $HOME/workspace/modern-farm/src/styles
-mkdir -p $HOME/workspace/modern-farm/test
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/modern-farm/src/scripts/seeds"
+mkdir -p "$WORKSPACE/modern-farm/src/styles"
+mkdir -p "$WORKSPACE/modern-farm/test"
 
-cd $HOME/workspace/modern-farm
+cd "$WORKSPACE/modern-farm"
 git init
 
 echo '{
@@ -53,7 +54,7 @@ echo '{
 }
 ' > package.json
 
-cd $HOME/workspace/modern-farm/test
+cd "$WORKSPACE/modern-farm/test"
 
 echo 'import { createPlan } from "../src/scripts/plan.js"
 import { plantSeeds } from "../src/scripts/tractor.js";
@@ -188,7 +189,7 @@ describe("Harvesting the grown plants", () => {
 })
 ' > farm.test.js
 
-cd $HOME/workspace/modern-farm/src
+cd "$WORKSPACE/modern-farm/src"
 
 echo '<!doctype html>
 <html lang="en">

--- a/projects/tier-2/state-fair/chapters/scripts/statefair-install.sh
+++ b/projects/tier-2/state-fair/chapters/scripts/statefair-install.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/statefair
-mkdir -p $HOME/workspace/statefair/scripts/rides
-mkdir -p $HOME/workspace/statefair/scripts/food
-mkdir -p $HOME/workspace/statefair/scripts/games
-mkdir -p $HOME/workspace/statefair/scripts/sideshows
-mkdir -p $HOME/workspace/statefair/styles
-cd $HOME/workspace/statefair
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/statefair"
+mkdir -p "$WORKSPACE/statefair/scripts/rides"
+mkdir -p "$WORKSPACE/statefair/scripts/food"
+mkdir -p "$WORKSPACE/statefair/scripts/games"
+mkdir -p "$WORKSPACE/statefair/scripts/sideshows"
+mkdir -p "$WORKSPACE/statefair/styles"
+cd "$WORKSPACE/statefair"
 
 
 echo '<!doctype html>

--- a/projects/tier-2/state-fair/chapters/scripts/statefair-install.sh
+++ b/projects/tier-2/state-fair/chapters/scripts/statefair-install.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/statefair"
 mkdir -p "$NSS_WORKSPACE/statefair/scripts/rides"
 mkdir -p "$NSS_WORKSPACE/statefair/scripts/food"

--- a/projects/tier-2/state-fair/chapters/scripts/statefair-install.sh
+++ b/projects/tier-2/state-fair/chapters/scripts/statefair-install.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/statefair"
-mkdir -p "$WORKSPACE/statefair/scripts/rides"
-mkdir -p "$WORKSPACE/statefair/scripts/food"
-mkdir -p "$WORKSPACE/statefair/scripts/games"
-mkdir -p "$WORKSPACE/statefair/scripts/sideshows"
-mkdir -p "$WORKSPACE/statefair/styles"
-cd "$WORKSPACE/statefair"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/statefair"
+mkdir -p "$NSS_WORKSPACE/statefair/scripts/rides"
+mkdir -p "$NSS_WORKSPACE/statefair/scripts/food"
+mkdir -p "$NSS_WORKSPACE/statefair/scripts/games"
+mkdir -p "$NSS_WORKSPACE/statefair/scripts/sideshows"
+mkdir -p "$NSS_WORKSPACE/statefair/styles"
+cd "$NSS_WORKSPACE/statefair"
 
 
 echo '<!doctype html>

--- a/projects/tier-4/giffygram/chapters/scripts/giffygram-styles.sh
+++ b/projects/tier-4/giffygram/chapters/scripts/giffygram-styles.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -u
 
-NSS_WORKSPACE="$HOME/workspace"
+# ${VAR=default} syntax uses whatever is on the right of the equals sign if the variable is unset *without triggering an error caused by `set -u`*
+echo Using workspace: ${NSS_WORKSPACE="$HOME/workspace"}
+
 mkdir -p "$NSS_WORKSPACE/giffygram/src/styles"
 cd "$NSS_WORKSPACE/giffygram/src/styles"
 

--- a/projects/tier-4/giffygram/chapters/scripts/giffygram-styles.sh
+++ b/projects/tier-4/giffygram/chapters/scripts/giffygram-styles.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -u
 
-mkdir -p $HOME/workspace/giffygram/src/styles
-cd $HOME/workspace/giffygram/src/styles
+WORKSPACE="$HOME/workspace"
+mkdir -p "$WORKSPACE/giffygram/src/styles"
+cd "$WORKSPACE/giffygram/src/styles"
 
 echo '@import "navigation.css";
 @import "footer.css";

--- a/projects/tier-4/giffygram/chapters/scripts/giffygram-styles.sh
+++ b/projects/tier-4/giffygram/chapters/scripts/giffygram-styles.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -u
 
-WORKSPACE="$HOME/workspace"
-mkdir -p "$WORKSPACE/giffygram/src/styles"
-cd "$WORKSPACE/giffygram/src/styles"
+NSS_WORKSPACE="$HOME/workspace"
+mkdir -p "$NSS_WORKSPACE/giffygram/src/styles"
+cd "$NSS_WORKSPACE/giffygram/src/styles"
 
 echo '@import "navigation.css";
 @import "footer.css";


### PR DESCRIPTION
All the setup scripts originally had the workspace location hardcoded in every `cd` and `mkdir` command.

Now, all `cd` and `mkdir` commands operate on a path prefixed by `$NSS_WORKSPACE`, which is echoed at the start of the script. `NSS_WORKSPACE` defaults to `$HOME/workspace` but can be overridden by setting the `NSS_WORKSPACE` variable in your non-interactive bash environment.

Setting a variable for a non-interactive (script) shell is a *little* tricky at first, but far less error prone than modifying the scripts by hand. I've added the relevant setup instructions to `book-1-martins-aquarium/chapters/CUSTOM_WORKSPACE.md`. They're also included below.


## To Test
First, set up your environment.
```
echo "export NSS_WORKSPACE=%workspace-dir%" >> ~/.bash_env
echo "export BASH_ENV=$HOME/.bash_env" >> ~/.bashrc
```
Then try running all of the scripts and verify that they used `%workspace-dir%`.
