### PR TITLE
Fixed sink-repair-setup.sh not properly creating SinkRepair.js

### DIFF
--- a/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
+++ b/book-5-a-sink-repair/chapters/scripts/sink-repair-setup.sh
@@ -73,7 +73,7 @@ export const SinkRepair = () => {
     </section>
     `
 }
-'
+' > ./scripts/SinkRepair.js
 
 echo 'import { SinkRepair } from "./SinkRepair.js"
 


### PR DESCRIPTION
## To Test
Run the updated `sink-repair-setup.sh` and verify that the contents of  `SinkRepair.js` are redirected to `./scripts/SinkRepair.js` rather than echoed out to the terminal.