### PR TITLE
Use correct syntax to create a copy of array of objects

### DIFF
--- a/book-1-martins-aquarium/chapters/MA_EXPORTING_FISH.md
+++ b/book-1-martins-aquarium/chapters/MA_EXPORTING_FISH.md
@@ -14,14 +14,13 @@ The database module will maintain the state, but other modules need copies of th
 
 The function is exported so other modules can import it and use it.
 
-Don't worry about understanding the [...] syntax here.
-Just remember that it copies an array. Understanding comes with time and practice.
+Don't worry about understanding all of the syntax here. Just remember that it copies the objects in an array. Understanding comes with time and practice.
 
 > **`workspace/martins-aquarium/scripts/database.js`**
 
 ```js
 export const getFish = () => {
-    return [...database.fish]
+    return database.fish.map(fish => ({...fish}))
 }
 ```
 

--- a/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/brewed-setup.sh
@@ -219,15 +219,15 @@ const database = {
 }
 
 export const getProducts = () => {
-    return [...database.products]
+    return database.products.map(product => ({...product}))
 }
 
 export const getEmployees = () => {
-    return [...database.employees]
+    return database.employees.map(employee => ({...employee}))
 }
 
 export const getOrders = () => {
-    return [...database.orders]
+    return database.orders.map(order => ({...order}))
 }
 ' > ./scripts/database.js
 

--- a/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
+++ b/book-3-deshawns-dog-walking/chapters/scripts/deshawn-setup.sh
@@ -195,11 +195,11 @@ const database = {
 }
 
 export const getWalkers = () => {
-    return [...database.walkers]
+    return database.walkers.map(walker => ({...walker}))
 }
 
 export const getPets = () => {
-    return [...database.pets]
+    return database.pets.map(pet => ({...pet}))
 }
 ' > ./scripts/database.js
 

--- a/book-4-kneel-diamonds/chapters/KD_STATECHANGED_EVENT.md
+++ b/book-4-kneel-diamonds/chapters/KD_STATECHANGED_EVENT.md
@@ -20,7 +20,8 @@ export const addCustomOrder = () => {
     const newOrder = {...database.orderBuilder}
 
     // Add a new primary key to the object
-    newOrder.id = [...database.customOrders].pop().id + 1
+    const lastIndex = database.customOrders.length - 1
+    newOrder.id = database.customOrders[lastIndex].id + 1
 
     // Add a timestamp to the order
     newOrder.timestamp = Date.now()

--- a/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
+++ b/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
@@ -120,7 +120,7 @@ const database = {
 }
 
 export const getMetals = () => {
-    return [...database.metals]
+    return database.metals.map(metal => ({...metal}))
 }
 ' > ./scripts/database.js
 

--- a/projects/tier-1/daily-journal/chapters/DAILY_JOURNAL_OBJECT_DOM.md
+++ b/projects/tier-1/daily-journal/chapters/DAILY_JOURNAL_OBJECT_DOM.md
@@ -45,7 +45,7 @@ const database = {
     raw data in the format that you want
 */
 export const getJournalEntries = () => {
-    const copyOfData = [...database.entries]
+    const copyOfData = database.entries.map(entry => ({...entry}))
     return copyOfData
 }
 ```

--- a/projects/tier-2/dothard-simbleton/chapters/DS_INTRO.md
+++ b/projects/tier-2/dothard-simbleton/chapters/DS_INTRO.md
@@ -224,7 +224,7 @@ const supplies = [
 ]
 
 export const getSupplies = () => {
-    const copyOfData = [...supplies]
+    const copyOfData = supplies.map(item => ({...item}))
     return copyOfData
 }
 ```

--- a/projects/tier-4/giffygram/chapters/GG_STATE_STORE.md
+++ b/projects/tier-4/giffygram/chapters/GG_STATE_STORE.md
@@ -84,7 +84,7 @@ This will make more sense later. Just remember that making copies of your data =
 */
 export const getAllUsers = () => {
     // Create a copy of users array
-    const usersCopy = [...applicationState.users]
+    const usersCopy = applicationState.users.map(user => ({...user}))
 
     // Make the copy the output of the function
     return usersCopy


### PR DESCRIPTION
Based on the recent discovery that all of the code that showed the spread syntax for generating copies of data was completely incorrect, I've replaced all instances of it in the course with the correct syntax.

Please review and provide comments about this proposed change. The related copy that tells students to not worry about how it works, rather to use it when a copy is needed, remains unchanged.