### PR TITLE
Added missing link to exporting fish chapter

### DIFF
--- a/book-1-martins-aquarium/README.md
+++ b/book-1-martins-aquarium/README.md
@@ -20,7 +20,8 @@
 | # | 🐠 <br/> Martin's Aquarium |
 |--|--|
 | 1 | [Objectifying the Fish](./chapters/MA_DATA_STRUCTURES.md) |
-| 2 | [HTML Representations of Data](./chapters/MA_CREATING_FISH_COMPONENTS.md) |
+| 2 | [Provide Access to Fish](./chapters/MA_EXPORTING_FISH.md) |
+| 3 | [HTML Representations of Data](./chapters/MA_CREATING_FISH_COMPONENTS.md) |
 
 ## Pioneer Chapters
 

--- a/book-1-martins-aquarium/chapters/MA_DATA_STRUCTURES.md
+++ b/book-1-martins-aquarium/chapters/MA_DATA_STRUCTURES.md
@@ -94,5 +94,3 @@ const database = {
 1. What is the data type of the `name` property?
 1. What is the data type of the `size` property?
 1. What data types will the fish array contain?
-
-


### PR DESCRIPTION
There was a chapter missing from the Explorer section of Book 1 that shows students how to export data from the database module. This change adds a new chapter link to that content.