### PR TITLE
Update kneel diamonds script to match video experience

### DIFF
--- a/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
+++ b/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh
@@ -126,6 +126,9 @@ export const getMetals = () => {
 
 echo '
 import { DiamondSizes } from "./DiamondSizes.js"
+import { JewelryStyles } from "./JewelryStyles.js"
+import { Orders } from "./Orders.js"
+
 document.addEventListener(
     "click",
     (event) => {
@@ -265,4 +268,3 @@ export const DiamondSizes = () => {
     return html
 }
 ' > ./scripts/DiamondSizes.js
-


### PR DESCRIPTION
Running the kneel diamonds script was only throwing one error, not the three described in the video solution. I added additional imports to the KneelDiamonds module to trigger those expected errors.

steps to test:

- run the curl statement from the chapter to install the script, but use branch name instead of cohort-49 in the url:
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nashville-software-school/client-side-mastery/js-kneel-diamonds-debug/book-4-kneel-diamonds/chapters/scripts/kneel-diamonds-setup.sh)"
```
- serve
- load in browser
- Should be three total errors. they are thrown one at a time as you fix the previous one