### PR TITLE
improve flow between chapters by eliminating inconsistency

### DIFF
--- a/book-6-nashville-kennels/chapters/DELETE.md
+++ b/book-6-nashville-kennels/chapters/DELETE.md
@@ -12,9 +12,9 @@ Since the provider components handle all interactions with the database, you nee
 ```js
 const releaseAnimal = animalId => {
     return fetch(`http://localhost:8088/animals/${animalId}`, {
-        method: "DELETE"
+      method: "DELETE"
     })
-        .then(getAnimals)
+      .then(getAnimals)
 }
 ```
 
@@ -45,6 +45,9 @@ Add a button to your animal details component that will allow the user to releas
 > ##### `/src/components/animal/AnimalDetails.js`
 
 ```js
+// ...
+// add useHistory to the import from the router library
+import { useParams, useHistory } from "react-router-dom"
 const history = useHistory()
 
 const handleRelease = () => {

--- a/book-6-nashville-kennels/chapters/EDIT.md
+++ b/book-6-nashville-kennels/chapters/EDIT.md
@@ -8,7 +8,7 @@ In this chapter, you are going to allow users to update an animal's name, locati
 
 > **React Documentation:** In HTML, form elements such as `<input>`, `<textarea>`, and `<select>` typically maintain their own state and update it based on user input. We then use something like `querySelector()` to get the values.
 
-> In React, mutable state is typically kept in the state property of components, and only updated with `setState()`.
+> In React, mutable state is typically kept in the state property of components, and only updated with the function that `useState()` gives us, ie `setFoo()` in `const [foo, setFoo] = useState()`
 
 Since we start with data from the API, our `render` displays values based on current state (or props). We need to always keep the current value of an input in the component's state. This allows for mutable state.
 
@@ -90,11 +90,11 @@ Replace the current contents of the **`AnimalForm`** component with the followin
 
 ```js
 import React, { useContext, useEffect, useState } from "react"
+import { useHistory, useParams } from 'react-router-dom';
 import { LocationContext } from "../location/LocationProvider"
 import { AnimalContext } from "../animal/AnimalProvider"
 import { CustomerContext } from "../customer/CustomerProvider"
 import "./Animal.css"
-import { useHistory, useParams } from 'react-router-dom';
 
 export const AnimalForm = () => {
     const { addAnimal, getAnimalById, updateAnimal } = useContext(AnimalContext)
@@ -128,7 +128,7 @@ export const AnimalForm = () => {
       } else {
         //disable the button - no extra clicks
         setIsLoading(true);
-        if (animalId){
+        if (animalId) {
           //PUT - update
           updateAnimal({
               id: animal.id,
@@ -137,7 +137,7 @@ export const AnimalForm = () => {
               customerId: parseInt(animal.customerId)
           })
           .then(() => history.push(`/animals/detail/${animal.id}`))
-        }else {
+        } else {
           //POST - add
           addAnimal({
               name: animal.name,
@@ -163,9 +163,6 @@ export const AnimalForm = () => {
         }
       })
     }, [])
-
-    //since state controlls this component, we no longer need
-    //useRef(null) or ref
 
     return (
       <form className="animalForm">
@@ -211,7 +208,7 @@ export const AnimalForm = () => {
             event.preventDefault() // Prevent browser from submitting the form and refreshing the page
             handleSaveAnimal()
           }}>
-        {animalId ? <>Save Animal</> : <>Add Animal</>}</button>
+        {animalId ? Save Animal : Add Animal }</button>
       </form>
     )
 }

--- a/book-6-nashville-kennels/chapters/FORMS_CONTROLLED_COMPONENT.md
+++ b/book-6-nashville-kennels/chapters/FORMS_CONTROLLED_COMPONENT.md
@@ -29,25 +29,22 @@ In React, we add event listeners directly on a button's `onClick` attribute.
 > ##### `src/components/animal/AnimalList.js`
 
 ```jsx
+// add this after all the other imports and variable declarations
 const history = useHistory()
 
+// Add the button above the list of animals ( BTW, the "..." means this is where some code lives but no need to type it all out here again)
 return (
     <>
-        <h2>Animals</h2>
-		<button onClick={() => {history.push("/animals/create")}}>
-            Add Animal
-        </button>
-        <div className="animals">
-        {
-			animals.map(animal => {
-				return <AnimalCard key={animal.id} animal={animal} />
-			})
-        }
-        </div>
+      <h2>Animals</h2>
+      <button onClick={() => {history.push("/animals/create")}}>
+          Add Animal
+      </button>
+      <div className="animals">
+        ...
+      </div>
     </>
 )
 ```
-
 
 ### Create the Route
 
@@ -59,12 +56,12 @@ Create the new route that will respond when the button click changes the URL to 
 
 ```jsx
 <AnimalProvider>
-  <Route exact path="/animals">
-      <AnimalList />
-  </Route>
-
   <CustomerProvider>
     <LocationProvider>
+      <Route exact path="/animals">
+        <AnimalList />
+      </Route>
+
       <Route exact path="/animals/create">
         <AnimalForm />
       </Route>
@@ -73,6 +70,7 @@ Create the new route that will respond when the button click changes the URL to 
 </AnimalProvider>
 
 ```
+If this nesting providers stuff doesn't make sense, don't just paste it and accept it. Ask about it.
 
 ### Create the Form Component
 

--- a/book-6-nashville-kennels/chapters/LIST_USECONTEXT.md
+++ b/book-6-nashville-kennels/chapters/LIST_USECONTEXT.md
@@ -22,13 +22,13 @@ export const AnimalList = () => {
   useEffect(() => {
     console.log("AnimalList: useEffect - getAnimals")
     getAnimals()
-
   }, [])
 
 
   return (
     <div className="animals">
       {console.log("AnimalList: Render", animals)}
+      <h2>Animals</h2>
       {
         animals.map(animal => {
           return <AnimalCard key={animal.id} animal={animal} />

--- a/book-6-nashville-kennels/chapters/MULTIPLE_PROVIDERS.md
+++ b/book-6-nashville-kennels/chapters/MULTIPLE_PROVIDERS.md
@@ -1,8 +1,6 @@
 # Joining Data in Multiple Resources
 
-Sometimes we need data from multiple resources. For example, to add a new animal with dropdown options for both the locations and the customer.
-
-In the next chapter we will create the AnimalForm component but first we need data from the location provider and customer provider. Update the **`ApplicationViews`** so the component has all the necessary providers as parent components.
+To expand our animal list to show the customer we need data from the location provider and customer provider. Update the **`ApplicationViews`** so the component has all the necessary providers as parent components.
 
 > ##### `src/components/ApplicationViews.js`
 
@@ -10,8 +8,8 @@ In the next chapter we will create the AnimalForm component but first we need da
 <AnimalProvider>
     <LocationProvider>
         <CustomerProvider>
-            <Route exact path="/animals/create">
-                <AnimalForm />
+            <Route exact path="/animals">
+                <AnimalList />
             </Route>
         </CustomerProvider>
     </LocationProvider>
@@ -22,17 +20,17 @@ Now the **`AnimalList`** component can access data from all three data providers
 
 ## Using Multiple Contexts
 
-The next step is to access the context from the two, new providers. Then you need to use the `useContext()` hook to get the state variables, and the functions to get the data from the API for each of those providers.
+The next step is to access the context from the two new providers. Then, you need to use the `useContext()` hook to get the state variables, and the functions to get the data from the API for each of those providers.
 
 > ##### `src/components/animal/AnimalList.js`
 
 ```js
-import React, { useContext } from "react"
+import React, { useContext, useEffect } from "react"
 import { AnimalContext } from "./AnimalProvider"
 import { LocationContext } from "../location/LocationProvider"
 import { CustomerContext } from "../customer/CustomerProvider"
-import { Animal } from "./Animal"
-import "./Animals.css"
+import { AnimalCard } from "./AnimalCard"
+import "./Animal.css"
 
 export const AnimalList = () => {
     const { animals, getAnimals } = useContext(AnimalContext)
@@ -48,9 +46,18 @@ export const AnimalList = () => {
 
 
     return (
+      <>
+        <button onClick={() => {history.push("/animals/create")}}>
+            Add Animal
+        </button>
         <div className="animals">
-            {animals.map(animal => <Animal key={animal.id} animal={animal} />)}
+          {
+            animals.map(animal => {
+              return <AnimalCard key={animal.id} animal={animal} />
+            })
+          }
         </div>
+      </>
     )
 }
 ```
@@ -64,16 +71,16 @@ Then you need to refactor your function that you are passing to the `.map()` met
 ```jsx
 animals.map(animal => {
     const owner = customers.find(c => c.id === animal.customerId)
-    const clinic = locations.find(l => l.id === animal.locationId)
+    const location = locations.find(l => l.id === animal.locationId)
 
-    return <Animal key={animal.id}
-                location={clinic}
+    return <AnimalCard key={animal.id}
+                location={location}
                 customer={owner}
                 animal={animal} />
-})
+  })
 ```
 
-Again, here's what is actually sent to the **`Animal`** component.
+Again, here's what is actually sent to the **`AnimalCard`** component.
 
 ```js
 {
@@ -86,15 +93,25 @@ Again, here's what is actually sent to the **`Animal`** component.
 
 ## Display Full Names
 
-The last step is to extract the new `customer` and `animal` keys on the object passed to the **`Animal`** component.
+The last step is to extract the new `customer` and `animal` keys on the object passed to the **`AnimalCard`** component, then display the name property of each one. 
+> NOTE that in this example that `location` is not a property of animal, as in the earlier chapter. Why? See the bottom of the page after you make sure your code works.
 
-> ##### `src/components/animal/Animal.js`
+> ##### `src/components/animal/AnimalCard.js`
 
 ```jsx
-export const Animal = ({ animal, customer, location }) => (
-```
-
-Then display the name property of each one.
-
-Now the **`AnimalForm`** component can access data from all of the data providers to produce dropdown options.
+export const AnimalCard = ({ animal, customer, location }) => (
+    <section className="animal">
+      <h3 className="animal__name">{animal.name}</h3>
+      <div className="animal__breed">{animal.breed}</div>
+      <div className="animal__location">Location: {location.name}</div>
+      <div className="animal__owner">Customer: {customer.name}</div>
+    </section>
+  )
+```  
 ![animal card showing name of customer and location](./images/animals-after-join.png)
+
+### _Expand_ your thinking
+You may have noticed something weird in this chapter about the `locations` state. Mainly, it isn't really needed. Why? Think back to when you created the **AnimalProvider** component. In `getAnimals` you use `_expand=location`. Do you remember what that does? Why does it make it unnecessary to use the **LocationContext** in this component? 
+
+Which approach seems 'better' to you? Why? Could we also remove the need for the **CustomerContext**? How? If you want to talk this out with an instructor, grab one and hash it out! Or, group up with some classmates and think outloud with them.
+`

--- a/book-6-nashville-kennels/chapters/USING_NESTED_DATA.md
+++ b/book-6-nashville-kennels/chapters/USING_NESTED_DATA.md
@@ -209,7 +209,7 @@ As mentioned before, these questions get to the core of understanding how routin
 
 ## Try it Out
 
-Now when you click on an animal's name in the list view, you should see your new animal detail view.
+Now when you click on an animal's name in the list view, you should see your new animal detail view. Note that this image shows buttons that we will be adding in the next chapters. Stay tuned!
 
 ![image of animal detail view](./images/animal-details.gif)
 


### PR DESCRIPTION
This PR comes as a result of feedback from a C49 student about major inconsistencies in the React chapters. Digging into it I discovered additional relics, timeline issues and outdated references. I've attempted to sync up all the chapters so that later ones don't contradict earlier ones and removed some stuff that doesn't need to be there at all any more.

I consider this a stopgap measure, though. A larger discussion about the appropriate timing of when we introduce `_expand` is needed, since currently there is still a very awkward segue in and out of its use. 