### PR TITLE
remove redundant instrux to create addAnimal function

### DIFF
--- a/book-6-nashville-kennels/chapters/DATA_PROVIDER.md
+++ b/book-6-nashville-kennels/chapters/DATA_PROVIDER.md
@@ -27,7 +27,6 @@ export const addAnimal = animalObj => {
         },
         body: JSON.stringify(animalObj)
     })
-    .then(res => res.json())
     .then(getAnimals)
 }
 ```
@@ -59,7 +58,7 @@ export const AnimalProvider = (props) => {
         .then(setAnimals)
     }
 
-    const addAnimal = animalObj => {
+    const addAnimal = (animalObj) => {
         return fetch("http://localhost:8088/animals", {
             method: "POST",
             headers: {

--- a/book-6-nashville-kennels/chapters/FORMS_CONTROLLED_COMPONENT.md
+++ b/book-6-nashville-kennels/chapters/FORMS_CONTROLLED_COMPONENT.md
@@ -202,19 +202,19 @@ export const AnimalForm = () => {
 
 ### Provider Function to Save Animal
 
-Now it is time for you to save your animal. First, create a function in your provider to perform the fetch operation. Make sure to add it to the value attribute of your `AnimalConext.Provider`.
+Now it is time for you to save your animal. If you remember, you already added a function for an animal POST request to `AnimalConext.Provider` in an earlier chapter. Here it is again to remind you. It sends an animal object to the db to be saved, then calls `getAnimals()` to update the application state with the new array of animals.
 
 ```js
-const addAnimal = animal => {
-    return fetch("http://localhost:8088/animals", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify(animal)
-    })
-    .then(response => response.json())
-}
+    const addAnimal = (animalObj) => {
+        return fetch("http://localhost:8088/animals", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(animalObj)
+        })
+        .then(getAnimals)
+    }
 ```
 
 ### Show All Animals on Save


### PR DESCRIPTION
After initially creating the Animal provider in DATA_PROVIDER.md that includes an `AddAnimal` function, students are instructed to create that function again in FORMS_CONTROLLED_COMPONENT.

This PR re-frames the reference in FORMS_CONTROLLED_COMPONENT to a reminder that the function already exists. I also removed an unnecessary `.then( res => res.json())`, since `AddAnimal` doesn't use any returned data.