### PR TITLE
Removing duplicate instructions

### DIFF
--- a/book-1-martins-aquarium/chapters/GETTING_STARTED_MAC.md
+++ b/book-1-martins-aquarium/chapters/GETTING_STARTED_MAC.md
@@ -56,18 +56,6 @@ Visit the [Homebrew](http://brew.sh/) website and follow the single instruction 
 
 After installing Homebrew, you may get the following warning:
 
-`/opt/homebrew/bin is not in your PATH`
-
-This may be fixed with this command:
-
-```
-export PATH=/opt/homebrew/bin:$PATH
-```
-
-#### Troubleshooting for instructors (don't try this yourself)
-
-After installing Homebrew, you may get the following warning:
-
 ```
 /opt/homebrew/bin is not in your PATH
 ```


### PR DESCRIPTION
There are duplicate instructions under the troubleshooting for instructors on Homebrew.